### PR TITLE
Add patches for USI-MKS drills

### DIFF
--- a/Extras/SystemHeatHarvesters/UmbraSpaceIndustries/MKSDrills.cfg
+++ b/Extras/SystemHeatHarvesters/UmbraSpaceIndustries/MKSDrills.cfg
@@ -1,0 +1,701 @@
+// Modifies USI drills to use SystemHeat modules
+
+@PART[MKS_Drill_01]:FOR[SystemHeatHarvesters]
+{
+  !MODULE[ModuleCoreHeat] {}
+  !MODULE[ModuleOverheatDisplay] {}
+
+  MODULE
+  {
+    name = ModuleSystemHeat
+    // Cubic metres
+    volume = 1.0
+    moduleID = harvester
+    iconName = Icon_Drill
+  }
+
+  @MODULE[USI_Harvester]
+  {
+
+    !ThermalEfficiency  {} 
+    !TemperatureModifier {}
+    
+    @GeneratesHeat = false
+  }
+
+  MODULE
+  {
+    name = ModuleSystemHeatHarvester
+    // must be unique
+    moduleID = harvester
+    // ModuleSystemHeat moduleID to link to
+    systemHeatModuleID = harvester
+
+    // The shutdown temperature of the part
+    shutdownTemperature = 750
+
+    // The temperature the system contributes to loops
+    systemOutletTemperature = 400
+
+    // Map loop temperature to system efficiency (0-1.0)
+    systemEfficiency
+    {
+        key = 0 1.0
+        key = 400 1.0
+        key = 650 0.0
+    }
+    
+    // Heat generation (kW)
+    systemPower = 30
+
+    // ModuleResourceHarvester  base
+    HarvesterType = 0
+		Efficiency = 0 // Dummy
+		ResourceName = Dirt // Usually more present than Ore.
+		ConverterName = #autoLOC_502038 //#autoLOC_502038 = Surface Harvester
+		StartActionName = #autoLOC_502039 //#autoLOC_502039 = Start Surface Harvester
+		StopActionName = #autoLOC_502040 //#autoLOC_502040 = Stop Surface Harvester
+		ToggleActionName = #autoLOC_502041 //#autoLOC_502041 = Toggle Surface Harvester
+		ImpactTransform = ImpactTransform
+		ImpactRange = 5.42
+		AutoShutdown = true
+
+    UseSpecialistBonus = true
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		UseSpecialistHeatBonus = true
+		SpecialistHeatFactor = 0.1
+		ExperienceEffect = DrillSkill
+		EfficiencyBonus = 1
+  }
+}
+
+@PART[MKS_Drill_01A]:FOR[SystemHeatHarvesters]
+{
+  !MODULE[ModuleCoreHeat] {}
+  !MODULE[ModuleOverheatDisplay] {}
+
+  MODULE
+  {
+    name = ModuleSystemHeat
+    // Cubic metres
+    volume = 1.0
+    moduleID = harvester
+    iconName = Icon_Drill
+  }
+
+  @MODULE[USI_Harvester]
+  {
+
+    !ThermalEfficiency  {} 
+    !TemperatureModifier {}
+    
+    @GeneratesHeat = false
+  }
+
+  MODULE
+  {
+    name = ModuleSystemHeatHarvester
+    // must be unique
+    moduleID = harvester
+    // ModuleSystemHeat moduleID to link to
+    systemHeatModuleID = harvester
+
+    // The shutdown temperature of the part
+    shutdownTemperature = 750
+
+    // The temperature the system contributes to loops
+    systemOutletTemperature = 400
+
+    // Map loop temperature to system efficiency (0-1.0)
+    systemEfficiency
+    {
+        key = 0 1.0
+        key = 400 1.0
+        key = 650 0.0
+    }
+    
+    // Heat generation (kW)
+    systemPower = 30
+
+    // ModuleResourceHarvester  base
+    HarvesterType = 0
+		Efficiency = 0 // Dummy
+		ResourceName = Dirt // Usually more present than Ore.
+		ConverterName = #autoLOC_502038 //#autoLOC_502038 = Surface Harvester
+		StartActionName = #autoLOC_502039 //#autoLOC_502039 = Start Surface Harvester
+		StopActionName = #autoLOC_502040 //#autoLOC_502040 = Stop Surface Harvester
+		ToggleActionName = #autoLOC_502041 //#autoLOC_502041 = Toggle Surface Harvester
+		ImpactTransform = ImpactTransform
+		ImpactRange = 5.42
+		AutoShutdown = true
+
+    UseSpecialistBonus = true
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		UseSpecialistHeatBonus = true
+		SpecialistHeatFactor = 0.1
+		ExperienceEffect = DrillSkill
+		EfficiencyBonus = 1
+  }
+}
+
+@PART[MKS_Drill_02]:FOR[SystemHeatHarvesters]
+{
+  !MODULE[ModuleCoreHeat] {}
+  !MODULE[ModuleOverheatDisplay] {}
+
+  MODULE
+  {
+    name = ModuleSystemHeat
+    // Cubic metres
+    volume = 1.0
+    moduleID = harvester
+    iconName = Icon_Drill
+  }
+
+  @MODULE[USI_Harvester]
+  {
+
+    !ThermalEfficiency  {} 
+    !TemperatureModifier {}
+    
+    @GeneratesHeat = false
+  }
+
+  MODULE
+  {
+    name = ModuleSystemHeatHarvester
+    // must be unique
+    moduleID = harvester
+    // ModuleSystemHeat moduleID to link to
+    systemHeatModuleID = harvester
+
+    // The shutdown temperature of the part
+    shutdownTemperature = 750
+
+    // The temperature the system contributes to loops
+    systemOutletTemperature = 400
+
+    // Map loop temperature to system efficiency (0-1.0)
+    systemEfficiency
+    {
+        key = 0 1.0
+        key = 400 1.0
+        key = 650 0.0
+    }
+    
+    // Heat generation (kW)
+    systemPower = 90
+
+    // ModuleResourceHarvester  base
+    HarvesterType = 0
+		Efficiency = 0 // Dummy
+		ResourceName = Dirt // Usually more present than Ore.
+		ConverterName = #autoLOC_502038 //#autoLOC_502038 = Surface Harvester
+		StartActionName = #autoLOC_502039 //#autoLOC_502039 = Start Surface Harvester
+		StopActionName = #autoLOC_502040 //#autoLOC_502040 = Stop Surface Harvester
+		ToggleActionName = #autoLOC_502041 //#autoLOC_502041 = Toggle Surface Harvester
+		ImpactTransform = ImpactTransform
+		ImpactRange = 5.42
+		AutoShutdown = true
+
+    UseSpecialistBonus = true
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		UseSpecialistHeatBonus = true
+		SpecialistHeatFactor = 0.1
+		ExperienceEffect = DrillSkill
+		EfficiencyBonus = 1
+  }
+}
+
+@PART[MKS_Drill_02A]:FOR[SystemHeatHarvesters]
+{
+  !MODULE[ModuleCoreHeat] {}
+  !MODULE[ModuleOverheatDisplay] {}
+
+  MODULE
+  {
+    name = ModuleSystemHeat
+    // Cubic metres
+    volume = 1.0
+    moduleID = harvester
+    iconName = Icon_Drill
+  }
+
+  @MODULE[USI_Harvester]
+  {
+
+    !ThermalEfficiency  {} 
+    !TemperatureModifier {}
+    
+    @GeneratesHeat = false
+  }
+
+  MODULE
+  {
+    name = ModuleSystemHeatHarvester
+    // must be unique
+    moduleID = harvester
+    // ModuleSystemHeat moduleID to link to
+    systemHeatModuleID = harvester
+
+    // The shutdown temperature of the part
+    shutdownTemperature = 750
+
+    // The temperature the system contributes to loops
+    systemOutletTemperature = 400
+
+    // Map loop temperature to system efficiency (0-1.0)
+    systemEfficiency
+    {
+        key = 0 1.0
+        key = 400 1.0
+        key = 650 0.0
+    }
+    
+    // Heat generation (kW)
+    systemPower = 90
+
+    // ModuleResourceHarvester  base
+    HarvesterType = 0
+		Efficiency = 0 // Dummy
+		ResourceName = Dirt // Usually more present than Ore.
+		ConverterName = #autoLOC_502038 //#autoLOC_502038 = Surface Harvester
+		StartActionName = #autoLOC_502039 //#autoLOC_502039 = Start Surface Harvester
+		StopActionName = #autoLOC_502040 //#autoLOC_502040 = Stop Surface Harvester
+		ToggleActionName = #autoLOC_502041 //#autoLOC_502041 = Toggle Surface Harvester
+		ImpactTransform = ImpactTransform
+		ImpactRange = 5.42
+		AutoShutdown = true
+
+    UseSpecialistBonus = true
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		UseSpecialistHeatBonus = true
+		SpecialistHeatFactor = 0.1
+		ExperienceEffect = DrillSkill
+		EfficiencyBonus = 1
+  }
+}
+
+@PART[MKS_Drill_03]:FOR[SystemHeatHarvesters]
+{
+  !MODULE[ModuleCoreHeat] {}
+  !MODULE[ModuleOverheatDisplay] {}
+
+  MODULE
+  {
+    name = ModuleSystemHeat
+    // Cubic metres
+    volume = 1.0
+    moduleID = harvester
+    iconName = Icon_Drill
+  }
+
+  @MODULE[USI_Harvester]
+  {
+
+    !ThermalEfficiency  {} 
+    !TemperatureModifier {}
+    
+    @GeneratesHeat = false
+  }
+
+  MODULE
+  {
+    name = ModuleSystemHeatHarvester
+    // must be unique
+    moduleID = harvester
+    // ModuleSystemHeat moduleID to link to
+    systemHeatModuleID = harvester
+
+    // The shutdown temperature of the part
+    shutdownTemperature = 750
+
+    // The temperature the system contributes to loops
+    systemOutletTemperature = 400
+
+    // Map loop temperature to system efficiency (0-1.0)
+    systemEfficiency
+    {
+        key = 0 1.0
+        key = 400 1.0
+        key = 650 0.0
+    }
+    
+    // Heat generation (kW)
+    systemPower = 180
+
+    // ModuleResourceHarvester  base
+    HarvesterType = 0
+		Efficiency = 0 // Dummy
+		ResourceName = Dirt // Usually more present than Ore.
+		ConverterName = #autoLOC_502038 //#autoLOC_502038 = Surface Harvester
+		StartActionName = #autoLOC_502039 //#autoLOC_502039 = Start Surface Harvester
+		StopActionName = #autoLOC_502040 //#autoLOC_502040 = Stop Surface Harvester
+		ToggleActionName = #autoLOC_502041 //#autoLOC_502041 = Toggle Surface Harvester
+		ImpactTransform = ImpactTransform
+		ImpactRange = 5.42
+		AutoShutdown = true
+
+    UseSpecialistBonus = true
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		UseSpecialistHeatBonus = true
+		SpecialistHeatFactor = 0.1
+		ExperienceEffect = DrillSkill
+		EfficiencyBonus = 1
+  }
+}
+
+@PART[MKS_Drill_03A]:FOR[SystemHeatHarvesters]
+{
+  !MODULE[ModuleCoreHeat] {}
+  !MODULE[ModuleOverheatDisplay] {}
+
+  MODULE
+  {
+    name = ModuleSystemHeat
+    // Cubic metres
+    volume = 1.0
+    moduleID = harvester
+    iconName = Icon_Drill
+  }
+
+  @MODULE[USI_Harvester]
+  {
+
+    !ThermalEfficiency  {} 
+    !TemperatureModifier {}
+    
+    @GeneratesHeat = false
+  }
+
+  MODULE
+  {
+    name = ModuleSystemHeatHarvester
+    // must be unique
+    moduleID = harvester
+    // ModuleSystemHeat moduleID to link to
+    systemHeatModuleID = harvester
+
+    // The shutdown temperature of the part
+    shutdownTemperature = 750
+
+    // The temperature the system contributes to loops
+    systemOutletTemperature = 400
+
+    // Map loop temperature to system efficiency (0-1.0)
+    systemEfficiency
+    {
+        key = 0 1.0
+        key = 400 1.0
+        key = 650 0.0
+    }
+    
+    // Heat generation (kW)
+    systemPower = 30
+
+    // ModuleResourceHarvester  base
+    HarvesterType = 0
+		Efficiency = 0 // Dummy
+		ResourceName = Dirt // Usually more present than Ore.
+		ConverterName = #autoLOC_502038 //#autoLOC_502038 = Surface Harvester
+		StartActionName = #autoLOC_502039 //#autoLOC_502039 = Start Surface Harvester
+		StopActionName = #autoLOC_502040 //#autoLOC_502040 = Stop Surface Harvester
+		ToggleActionName = #autoLOC_502041 //#autoLOC_502041 = Toggle Surface Harvester
+		ImpactTransform = ImpactTransform
+		ImpactRange = 5.42
+		AutoShutdown = true
+
+    UseSpecialistBonus = true
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		UseSpecialistHeatBonus = true
+		SpecialistHeatFactor = 0.1
+		ExperienceEffect = DrillSkill
+		EfficiencyBonus = 1
+  }
+}
+
+@PART[ATLAS_Harvester_Lg_a]:FOR[SystemHeatHarvesters]
+{
+  !MODULE[ModuleCoreHeat] {}
+  !MODULE[ModuleOverheatDisplay] {}
+
+  MODULE
+  {
+    name = ModuleSystemHeat
+    // Cubic metres
+    volume = 1.0
+    moduleID = harvester
+    iconName = Icon_Drill
+  }
+
+  @MODULE[USI_Harvester]
+  {
+
+    !ThermalEfficiency  {} 
+    !TemperatureModifier {}
+    
+    @GeneratesHeat = false
+  }
+
+  MODULE
+  {
+    name = ModuleSystemHeatHarvester
+    // must be unique
+    moduleID = harvester
+    // ModuleSystemHeat moduleID to link to
+    systemHeatModuleID = harvester
+
+    // The shutdown temperature of the part
+    shutdownTemperature = 750
+
+    // The temperature the system contributes to loops
+    systemOutletTemperature = 400
+
+    // Map loop temperature to system efficiency (0-1.0)
+    systemEfficiency
+    {
+        key = 0 1.0
+        key = 400 1.0
+        key = 650 0.0
+    }
+    
+    // Heat generation (kW)
+    systemPower = 1200
+
+    // ModuleResourceHarvester  base
+    HarvesterType = 0
+		Efficiency = 0 // Dummy
+		ResourceName = Dirt // Usually more present than Ore.
+		ConverterName = #autoLOC_502038 //#autoLOC_502038 = Surface Harvester
+		StartActionName = #autoLOC_502039 //#autoLOC_502039 = Start Surface Harvester
+		StopActionName = #autoLOC_502040 //#autoLOC_502040 = Stop Surface Harvester
+		ToggleActionName = #autoLOC_502041 //#autoLOC_502041 = Toggle Surface Harvester
+		ImpactTransform = ImpactTransform
+		ImpactRange = 5.42
+		AutoShutdown = true
+
+    UseSpecialistBonus = true
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		UseSpecialistHeatBonus = true
+		SpecialistHeatFactor = 0.1
+		ExperienceEffect = DrillSkill
+		EfficiencyBonus = 1
+  }
+}
+
+@PART[ATLAS_Harvester_Lg]:FOR[SystemHeatHarvesters]
+{
+  !MODULE[ModuleCoreHeat] {}
+  !MODULE[ModuleOverheatDisplay] {}
+
+  MODULE
+  {
+    name = ModuleSystemHeat
+    // Cubic metres
+    volume = 1.0
+    moduleID = harvester
+    iconName = Icon_Drill
+  }
+
+  @MODULE[USI_Harvester]
+  {
+
+    !ThermalEfficiency  {} 
+    !TemperatureModifier {}
+    
+    @GeneratesHeat = false
+  }
+
+  MODULE
+  {
+    name = ModuleSystemHeatHarvester
+    // must be unique
+    moduleID = harvester
+    // ModuleSystemHeat moduleID to link to
+    systemHeatModuleID = harvester
+
+    // The shutdown temperature of the part
+    shutdownTemperature = 750
+
+    // The temperature the system contributes to loops
+    systemOutletTemperature = 400
+
+    // Map loop temperature to system efficiency (0-1.0)
+    systemEfficiency
+    {
+        key = 0 1.0
+        key = 400 1.0
+        key = 650 0.0
+    }
+    
+    // Heat generation (kW)
+    systemPower = 1200
+
+    // ModuleResourceHarvester  base
+    HarvesterType = 0
+		Efficiency = 0 // Dummy
+		ResourceName = Dirt // Usually more present than Ore.
+		ConverterName = #autoLOC_502038 //#autoLOC_502038 = Surface Harvester
+		StartActionName = #autoLOC_502039 //#autoLOC_502039 = Start Surface Harvester
+		StopActionName = #autoLOC_502040 //#autoLOC_502040 = Stop Surface Harvester
+		ToggleActionName = #autoLOC_502041 //#autoLOC_502041 = Toggle Surface Harvester
+		ImpactTransform = ImpactTransform
+		ImpactRange = 5.42
+		AutoShutdown = true
+
+    UseSpecialistBonus = true
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		UseSpecialistHeatBonus = true
+		SpecialistHeatFactor = 0.1
+		ExperienceEffect = DrillSkill
+		EfficiencyBonus = 1
+  }
+}
+@PART[ATLAS_Harvester_Sm_a]:FOR[SystemHeatHarvesters]
+{
+  !MODULE[ModuleCoreHeat] {}
+  !MODULE[ModuleOverheatDisplay] {}
+
+  MODULE
+  {
+    name = ModuleSystemHeat
+    // Cubic metres
+    volume = 1.0
+    moduleID = harvester
+    iconName = Icon_Drill
+  }
+
+  @MODULE[USI_Harvester]
+  {
+
+    !ThermalEfficiency  {} 
+    !TemperatureModifier {}
+    
+    @GeneratesHeat = false
+  }
+
+  MODULE
+  {
+    name = ModuleSystemHeatHarvester
+    // must be unique
+    moduleID = harvester
+    // ModuleSystemHeat moduleID to link to
+    systemHeatModuleID = harvester
+
+    // The shutdown temperature of the part
+    shutdownTemperature = 750
+
+    // The temperature the system contributes to loops
+    systemOutletTemperature = 400
+
+    // Map loop temperature to system efficiency (0-1.0)
+    systemEfficiency
+    {
+        key = 0 1.0
+        key = 400 1.0
+        key = 650 0.0
+    }
+    
+    // Heat generation (kW)
+    systemPower = 600
+
+    // ModuleResourceHarvester  base
+    HarvesterType = 0
+		Efficiency = 0 // Dummy
+		ResourceName = Dirt // Usually more present than Ore.
+		ConverterName = #autoLOC_502038 //#autoLOC_502038 = Surface Harvester
+		StartActionName = #autoLOC_502039 //#autoLOC_502039 = Start Surface Harvester
+		StopActionName = #autoLOC_502040 //#autoLOC_502040 = Stop Surface Harvester
+		ToggleActionName = #autoLOC_502041 //#autoLOC_502041 = Toggle Surface Harvester
+		ImpactTransform = ImpactTransform
+		ImpactRange = 5.42
+		AutoShutdown = true
+
+    UseSpecialistBonus = true
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		UseSpecialistHeatBonus = true
+		SpecialistHeatFactor = 0.1
+		ExperienceEffect = DrillSkill
+		EfficiencyBonus = 1
+  }
+}
+
+@PART[ATLAS_Harvester_Sm]:FOR[SystemHeatHarvesters]
+{
+  !MODULE[ModuleCoreHeat] {}
+  !MODULE[ModuleOverheatDisplay] {}
+
+  MODULE
+  {
+    name = ModuleSystemHeat
+    // Cubic metres
+    volume = 1.0
+    moduleID = harvester
+    iconName = Icon_Drill
+  }
+
+  @MODULE[USI_Harvester]
+  {
+
+    !ThermalEfficiency  {} 
+    !TemperatureModifier {}
+    
+    @GeneratesHeat = false
+  }
+
+  MODULE
+  {
+    name = ModuleSystemHeatHarvester
+    // must be unique
+    moduleID = harvester
+    // ModuleSystemHeat moduleID to link to
+    systemHeatModuleID = harvester
+
+    // The shutdown temperature of the part
+    shutdownTemperature = 750
+
+    // The temperature the system contributes to loops
+    systemOutletTemperature = 400
+
+    // Map loop temperature to system efficiency (0-1.0)
+    systemEfficiency
+    {
+        key = 0 1.0
+        key = 400 1.0
+        key = 650 0.0
+    }
+    
+    // Heat generation (kW)
+    systemPower = 600
+
+    // ModuleResourceHarvester  base
+    HarvesterType = 0
+		Efficiency = 0 // Dummy
+		ResourceName = Dirt // Usually more present than Ore.
+		ConverterName = #autoLOC_502038 //#autoLOC_502038 = Surface Harvester
+		StartActionName = #autoLOC_502039 //#autoLOC_502039 = Start Surface Harvester
+		StopActionName = #autoLOC_502040 //#autoLOC_502040 = Stop Surface Harvester
+		ToggleActionName = #autoLOC_502041 //#autoLOC_502041 = Toggle Surface Harvester
+		ImpactTransform = ImpactTransform
+		ImpactRange = 5.42
+		AutoShutdown = true
+
+    UseSpecialistBonus = true
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		UseSpecialistHeatBonus = true
+		SpecialistHeatFactor = 0.1
+		ExperienceEffect = DrillSkill
+		EfficiencyBonus = 1
+  }
+}
+


### PR DESCRIPTION
It's a very janky workaround for https://github.com/post-kerbin-mining-corporation/SystemHeat/issues/132
MKS drills don't use `ModuleResourceHarvester` / `ModuleAsteroidDrill` modules, instead using separate `USI_Harvester` modules. 

These patches remove the heat generation from `USI_harvester` and create a `ModuleSystemHeatHarvester` module outputting hopefully similar heat generation - I did not test the systemPower values. It has 0 efficiency, so extracts nothing.

The implementation is pretty clunky, since it separates resource extraction from heat generation:
<img width="390" height="503" alt="image" src="https://github.com/user-attachments/assets/d8a2e90d-7e30-48b2-b751-75d8fc30096b" />
In ithis image the Gypsum rate, load and efficiency are created by USI-MKS .
SystemHeat tab and Surface Harvester are created by SystemHeat.

The `Start / Stop Gypsum drill` is USI-MKS resource extraction toggle .
The `Start / Stop Surface Harvester` toggle is SystemHeat heat generation toggle.
Yes, you can turn on just the MKS part and it will extract without creating heat - I dind't find a way to remove that limitation.
