### PR TITLE
Correctly calculate `consumedSystemFlux` for consumers

### DIFF
--- a/SystemHeat/SystemHeat/HeatLoop.cs
+++ b/SystemHeat/SystemHeat/HeatLoop.cs
@@ -228,8 +228,8 @@ namespace SystemHeat
       NegativeFlux = CalculateNegativeFlux();
       float absFlux = Mathf.Abs(currentNetFlux);
 
-      AllocateFlux(PositiveFlux);
       NetFlux = currentNetFlux;
+      float oldTemperature = Temperature;
 
       // Determine the ideal change in temperature
       float deltaTemperatureIdeal = NetFlux * 1000f / (Volume * CoolantType.Density * CoolantType.HeatCapacity) * simTimeStep;
@@ -280,6 +280,15 @@ namespace SystemHeat
         }
       }
 
+      // How much temperature have we lost in this step?
+      var tempLoss = Mathf.Max(oldTemperature - Temperature, 0f);
+      // ... and how much energy did that take?
+      var energyLoss = tempLoss * 0.001f * Volume * CoolantType.Density * CoolantType.HeatCapacity;
+      // Now if we spread that out over the time step how how much extra flux do we get?
+      var lossFlux = energyLoss / simTimeStep;
+
+      AllocateFlux(PositiveFlux + lossFlux);
+
       // Ensure temperature doesn't go super high or low when the KSP environment gets weird (scene transitions)
       Temperature = Mathf.Clamp(Temperature, GetEnvironmentTemperature(), float.MaxValue);
       // Propagate to all modules
@@ -298,39 +307,20 @@ namespace SystemHeat
 
     protected void AllocateFlux(float totalFlux)
     {
-      // Get all consuming systems
       for (int i = 0; i < modules.Count; i++)
       {
-        var module = modules[i];
-        if (module.totalSystemFlux >= 0) continue;
+        var consumer = modules[i];
+        if (consumer.totalSystemFlux >= 0f) continue;
 
-        if (totalFlux <= 0f)
-        {
-          module.consumedSystemFlux = 0f;
-        }
-        else
-        {
-          if (totalFlux + module.totalSystemFlux > 0f)
-          {
-            totalFlux += module.totalSystemFlux;
-            module.consumedSystemFlux = module.totalSystemFlux;
-          }
-          else if (totalFlux + module.totalSystemFlux == 0f)
-          {
-            module.consumedSystemFlux = 0f;
-            totalFlux = 0f;
-          }
-          else //(totalFlux + orderedConsumers[i].totalSystemFlux < 0f)
-          {
-            module.consumedSystemFlux = -totalFlux;
-            totalFlux = 0f;
-          }
-        }
+        var systemFlux = -consumer.totalSystemFlux;
+        if (totalFlux < systemFlux)
+          systemFlux = totalFlux;
 
+        totalFlux -= systemFlux;
+        consumer.consumedSystemFlux = -systemFlux;
       }
-
-
     }
+
     void SimulateConvection(float simTimeStep)
     {
      


### PR DESCRIPTION
This commit makes two different changes:
- It rewrites `HeatLoop.AllocateFlux` to avoid the issue where `consumedSystemFlux` is set to 0 if a system's `totalSystemFlux` is equal to `totalFlux` when it is checked.
- It changes the total flux available to allocate to also take into account negative flux used to lower the temperature of the loop.

With these two changes `consumedSystemFlux` should now be accurate when the loop temperature is >= its nominal temperature. It should now be possible to actually use it to drive downstream things based on the amount of heat used (e.g. consuming resources, transferring heat, or powering an engine).

I have taken care to make sure that the behaviour stays consistent when below the nominal temperature: flux will still be allocated to consumers based on the positive flux, even if this has no real effect on the loop itself.

Fixes #138