### PR TITLE
Various cleanups to `ModuleSystemHeat`

### DIFF
--- a/Source/Modules/ModuleSystemHeat.cs
+++ b/Source/Modules/ModuleSystemHeat.cs
@@ -103,9 +103,9 @@ namespace SystemHeat
     }
 
     protected SystemHeatSimulator simulator;
-    protected Dictionary<string, float> fluxes = [];
-    protected Dictionary<string, float> temperatures = [];
-    protected List<int> loopIDs = [];
+    protected readonly Dictionary<string, float> fluxes = [];
+    protected readonly Dictionary<string, float> temperatures = [];
+    protected readonly List<int> loopIDs = [];
 
     public override string GetModuleDisplayName()
     {

--- a/Source/Modules/ModuleSystemHeat.cs
+++ b/Source/Modules/ModuleSystemHeat.cs
@@ -120,7 +120,7 @@ namespace SystemHeat
     public override void OnAwake()
     {
       base.OnAwake();
-      
+
       for (int i = 0; i < SystemHeatSettings.maxLoopCount; i++)
         loopIDs.Add(i);
     }
@@ -147,90 +147,23 @@ namespace SystemHeat
     {
       BaseField chooseField = Fields["currentLoopID"];
       UI_ChooseOption chooseOption = HighLogic.LoadedSceneIsFlight ? chooseField.uiControlFlight as UI_ChooseOption : chooseField.uiControlEditor as UI_ChooseOption;
-      chooseOption.options = new string[] { "0", "1", "2", "3", "4", "5", "6", "7", "8", "9" };
+      chooseOption.options = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"];
       chooseOption.onFieldChanged = ChangeLoop;
     }
 
     private void ChangeLoop(BaseField field, object oldFieldValueObj)
     {
-      if (HighLogic.LoadedSceneIsFlight)
-      {
-        Utils.Log($"[ModuleSystemHeat] Changing part from loop {(int)oldFieldValueObj} to loop {currentLoopID}", LogType.Modules);
-        simulator.RemoveHeatModuleFromLoop((int)oldFieldValueObj, this);
-        simulator.AddHeatModuleToLoop(currentLoopID, this);
-      }
+      if (!HighLogic.LoadedSceneIsFlight)
+        return;
+
+      var oldLoopID = (int)oldFieldValueObj;
+      if (Utils.IsLogEnabled(LogType.Modules))
+        Utils.Log($"[ModuleSystemHeat] Changing part from loop {oldLoopID} to loop {currentLoopID}", LogType.Modules);
+      simulator.RemoveHeatModuleFromLoop(oldLoopID, this);
+      simulator.AddHeatModuleToLoop(currentLoopID, this);
     }
 
-    void ChangeAllLoops(object oldFieldValueObj)
-    {
-      if (HighLogic.LoadedSceneIsFlight)
-      {
-        Utils.Log($"[ModuleSystemHeat] Changing all loop {(int)oldFieldValueObj} modules to loop {currentLoopID}", LogType.Modules);
-        List<ModuleSystemHeat> allHeatModules = new List<ModuleSystemHeat>();
-        for (int i = 0; i < part.vessel.Parts.Count; i++)
-        {
-          if (part.vessel.Parts[i].GetComponent<ModuleSystemHeat>())
-          {
-            allHeatModules.Add(part.vessel.Parts[i].GetComponent<ModuleSystemHeat>());
-          }
-        }
-
-        // Find list of used heat modules
-        List<int> usedModules = new List<int>();
-        for (int i = 0; i < allHeatModules.Count; i++)
-        {
-          if (allHeatModules[i] != this)
-          {
-            if (!usedModules.Contains(allHeatModules[i].currentLoopID))
-            {
-              usedModules.Add(allHeatModules[i].currentLoopID);
-              Utils.Log($"[ModuleSystemHeat] {allHeatModules[i].currentLoopID} is in use", LogType.Modules);
-            }
-          }
-        }
-
-        bool unused = false;
-
-        int newID = currentLoopID;
-        while (!unused)
-        {
-
-          if (usedModules.Contains(newID))
-          {
-            Utils.Log($"[ModuleSystemHeat] {newID} is in use and cannot be used", LogType.Modules);
-            newID++;
-          }
-          else
-          {
-            unused = true;
-            Utils.Log($"[ModuleSystemHeat] {newID} will be the new ID", LogType.Modules);
-          }
-        }
-
-        for (int i = 0; i < allHeatModules.Count; i++)
-        {
-          if (allHeatModules[i] == this)
-          {
-            allHeatModules[i].currentLoopID = newID;
-
-            UIPartActionWindow window = UIPartActionController.Instance?.GetItem(part, false);
-            if (window == null) return;
-            window.displayDirty = true;
-          }
-          if (allHeatModules[i].currentLoopID == (int)oldFieldValueObj)
-          {
-
-
-            allHeatModules[i].currentLoopID = newID;
-
-          }
-        }
-        Utils.Log($"[ModuleSystemHeat] finished changing loop IDs to new {newID}", LogType.Modules);
-        simulator.ChangeLoopID((int)oldFieldValueObj, newID);
-      }
-    }
-
-    static ProfilerMarker x_AddFluxMarker = new ProfilerMarker("ModuleSystemHeat.AddFlux");
+    static readonly ProfilerMarker x_AddFluxMarker = new("ModuleSystemHeat.AddFlux");
 
     /// <summary>
     /// Add heat flux at a given temperature to system
@@ -244,7 +177,7 @@ namespace SystemHeat
     /// </param>
     public void AddFlux(string id, float sourceTemperature, float flux, bool useForNominal)
     {
-      x_AddFluxMarker.Begin();
+      using var scope = x_AddFluxMarker.Auto();
 
       if (fluxes != null && temperatures != null)
       {
@@ -292,8 +225,6 @@ namespace SystemHeat
           ignoreTemperature = false;
         }
       }
-
-      x_AddFluxMarker.End();
     }
 
     public float GetFlux(string id)
@@ -319,13 +250,12 @@ namespace SystemHeat
       if (simulator == null)
         FindSimulator();
 
-
       if (enabled && !moduleUsed)
       {
-        Utils.Log($"[ModuleSystemHeat] seting module {moduleID} system state from {moduleUsed} to {enabled}", LogType.Modules);
+        if (Utils.IsLogEnabled(LogType.Modules))
+          Utils.Log($"[ModuleSystemHeat] seting module {moduleID} system state from {moduleUsed} to {enabled}", LogType.Modules);
         moduleUsed = enabled;
-        if (simulator != null)
-          simulator.AddHeatModule(this);
+        simulator?.AddHeatModule(this);
 
         // turn things on
         Fields["SystemTemperatureUI"].guiActive = true;
@@ -337,12 +267,13 @@ namespace SystemHeat
         Fields["currentLoopID"].guiActive = true;
         Fields["currentLoopID"].guiActiveEditor = true;
       }
+
       if (!enabled && moduleUsed)
       {
-        Utils.Log($"[ModuleSystemHeat] seting module {moduleID} system state from {moduleUsed} to {enabled}", LogType.Modules);
+        if (Utils.IsLogEnabled(LogType.Modules))
+          Utils.Log($"[ModuleSystemHeat] seting module {moduleID} system state from {moduleUsed} to {enabled}", LogType.Modules);
         moduleUsed = enabled;
-        if (simulator != null)
-          simulator.RemoveHeatModule(this);
+        simulator?.RemoveHeatModule(this);
 
         // turn things off
         Fields["SystemTemperatureUI"].guiActive = false;
@@ -366,24 +297,24 @@ namespace SystemHeat
 
     protected void Update()
     {
-      if (HighLogic.LoadedSceneIsFlight || HighLogic.LoadedSceneIsEditor)
+      if (!HighLogic.LoadedSceneIsFlight && !HighLogic.LoadedSceneIsEditor)
+        return;
+
+      if (!moduleUsed || !part.IsPAWVisible())
+        return;
+
+      SystemFluxUI = String.Format("{0}W", Utils.ToSI(totalSystemFlux, "F0"));
+      LoopTemperatureUI = String.Format("{0:F0} / {1:F0} K", currentLoopTemperature, nominalLoopTemperature);
+      if (totalSystemFlux > 0f)
       {
-        if (part.IsPAWVisible() && moduleUsed)
-        {
-          SystemFluxUI = String.Format("{0}W", Utils.ToSI(totalSystemFlux, "F0"));
-          LoopTemperatureUI = String.Format("{0:F0} / {1:F0} K", currentLoopTemperature, nominalLoopTemperature);
-          if (totalSystemFlux > 0f)
-          {
-            Fields["SystemTemperatureUI"].guiActive = true;
-            Fields["SystemTemperatureUI"].guiActiveEditor = true;
-            SystemTemperatureUI = String.Format("{0:F0} K", totalSystemTemperature);
-          }
-          else
-          {
-            Fields["SystemTemperatureUI"].guiActive = false;
-            Fields["SystemTemperatureUI"].guiActiveEditor = false;
-          }
-        }
+        Fields["SystemTemperatureUI"].guiActive = true;
+        Fields["SystemTemperatureUI"].guiActiveEditor = true;
+        SystemTemperatureUI = String.Format("{0:F0} K", totalSystemTemperature);
+      }
+      else
+      {
+        Fields["SystemTemperatureUI"].guiActive = false;
+        Fields["SystemTemperatureUI"].guiActiveEditor = false;
       }
     }
 

--- a/Source/Modules/ModuleSystemHeat.cs
+++ b/Source/Modules/ModuleSystemHeat.cs
@@ -103,9 +103,9 @@ namespace SystemHeat
     }
 
     protected SystemHeatSimulator simulator;
-    protected Dictionary<string, float> fluxes;
-    protected Dictionary<string, float> temperatures;
-    protected List<int> loopIDs;
+    protected Dictionary<string, float> fluxes = [];
+    protected Dictionary<string, float> temperatures = [];
+    protected List<int> loopIDs = [];
 
     public override string GetModuleDisplayName()
     {
@@ -119,11 +119,6 @@ namespace SystemHeat
 
     public void Start()
     {
-
-      loopIDs = new List<int>();
-      fluxes = new Dictionary<string, float>();
-      temperatures = new Dictionary<string, float>();
-
       for (int i = 0; i < SystemHeatSettings.maxLoopCount; i++)
         loopIDs.Add(i);
 

--- a/Source/Modules/ModuleSystemHeat.cs
+++ b/Source/Modules/ModuleSystemHeat.cs
@@ -168,7 +168,7 @@ namespace SystemHeat
     /// </param>
     public void AddFlux(string id, float sourceTemperature, float flux, bool useForNominal)
     {
-      using var scope = x_AddFluxMarker.Auto();
+      using var scope = x_AddFluxMarker.ConditionalAuto();
 
       fluxes[id] = flux;
 

--- a/Source/Modules/ModuleSystemHeat.cs
+++ b/Source/Modules/ModuleSystemHeat.cs
@@ -82,17 +82,7 @@ namespace SystemHeat
     [KSPField(isPersistant = false, guiActive = true, guiActiveEditor = true, guiName = "#LOC_SystemHeat_ModuleSystemHeat_Field_LoopTemperature", groupName = "sysheatinfo", groupDisplayName = "#LOC_SystemHeat_ModuleSystemHeat_GroupName", groupStartCollapsed = false)]
     public string LoopTemperatureUI = "-";
 
-    public HeatLoop Loop
-    {
-      get
-      {
-        if (simulator != null)
-        {
-          return simulator.Loop(currentLoopID);
-        }
-        else return null;
-      }
-    }
+    public HeatLoop Loop => simulator?.Loop(currentLoopID);
 
     public int LoopID
     {

--- a/Source/Modules/ModuleSystemHeat.cs
+++ b/Source/Modules/ModuleSystemHeat.cs
@@ -105,7 +105,6 @@ namespace SystemHeat
     protected SystemHeatSimulator simulator;
     protected readonly Dictionary<string, float> fluxes = [];
     protected readonly Dictionary<string, float> temperatures = [];
-    protected readonly List<int> loopIDs = [];
 
     public override string GetModuleDisplayName()
     {
@@ -115,14 +114,6 @@ namespace SystemHeat
     public override string GetInfo()
     {
       return Localizer.Format("#LOC_SystemHeat_ModuleSystemHeat_PartInfo", volume.ToString("F2"));
-    }
-
-    public override void OnAwake()
-    {
-      base.OnAwake();
-
-      for (int i = 0; i < SystemHeatSettings.maxLoopCount; i++)
-        loopIDs.Add(i);
     }
 
     public void Start()
@@ -179,51 +170,48 @@ namespace SystemHeat
     {
       using var scope = x_AddFluxMarker.Auto();
 
-      if (fluxes != null && temperatures != null)
+      fluxes[id] = flux;
+
+      // Add if used for nominal
+      if (useForNominal)
       {
-        fluxes[id] = flux;
+        temperatures[id] = sourceTemperature;
+      }
+      else
+      {
+        temperatures[id] = 0f;
+      }
 
-        // Add if used for nominal
-        if (useForNominal)
+      totalSystemFlux = 0;
+      foreach (var f in fluxes.Values)
+      {
+        totalSystemFlux += f;
+      }
+      totalSystemFlux *= (float)(PhysicsGlobals.InternalHeatProductionFactor / 0.025d);
+      totalSystemTemperature = 0;
+      float denom = 0;
+      foreach (var temp in temperatures.Values)
+      {
+        if (temp > 0f)
         {
-          temperatures[id] = sourceTemperature;
+          totalSystemTemperature += temp;
+          denom++;
         }
-        else
-        {
-          temperatures[id] = 0f;
-        }
+      }
 
-        totalSystemFlux = 0;
-        foreach (var f in fluxes.Values)
-        {
-          totalSystemFlux += f;
-        }
-        totalSystemFlux *= (float)(PhysicsGlobals.InternalHeatProductionFactor / 0.025d);
-        totalSystemTemperature = 0;
-        float denom = 0;
-        foreach (var temp in temperatures.Values)
-        {
-          if (temp > 0f)
-          {
-            totalSystemTemperature += temp;
-            denom++;
-          }
-        }
+      if (denom > 0)
+        systemNominalTemperature = totalSystemTemperature / denom;
+      else
+        systemNominalTemperature = 0f;
 
-        if (denom > 0)
-          systemNominalTemperature = totalSystemTemperature / denom;
-        else
-          systemNominalTemperature = 0f;
-
-        totalSystemTemperature = systemNominalTemperature;
-        if (totalSystemTemperature == 0f)
-        {
-          ignoreTemperature = true;
-        }
-        else
-        {
-          ignoreTemperature = false;
-        }
+      totalSystemTemperature = systemNominalTemperature;
+      if (totalSystemTemperature == 0f)
+      {
+        ignoreTemperature = true;
+      }
+      else
+      {
+        ignoreTemperature = false;
       }
     }
 

--- a/Source/Modules/ModuleSystemHeat.cs
+++ b/Source/Modules/ModuleSystemHeat.cs
@@ -117,11 +117,16 @@ namespace SystemHeat
       return Localizer.Format("#LOC_SystemHeat_ModuleSystemHeat_PartInfo", volume.ToString("F2"));
     }
 
-    public void Start()
+    public override void OnAwake()
     {
+      base.OnAwake();
+      
       for (int i = 0; i < SystemHeatSettings.maxLoopCount; i++)
         loopIDs.Add(i);
+    }
 
+    public void Start()
+    {
       SetupUI();
 
       Fields["totalSystemTemperature"].guiActive = SystemHeatSettings.DebugPartUI;

--- a/Source/Utils.cs
+++ b/Source/Utils.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Unity.Profiling;
 using UnityEngine;
 
 
@@ -136,5 +138,29 @@ namespace SystemHeat
       }
       return null;
     }
+  }
+
+  internal static class ProfilingExt
+  {
+#if ENABLE_PROFILER
+    [method: MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal struct Scope(ProfilerMarker.AutoScope scope) : IDisposable
+    {
+      [MethodImpl(MethodImplOptions.AggressiveInlining)]
+      public readonly void Dispose() => scope.Dispose();
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static Scope ConditionalAuto(this ProfilerMarker marker) => new(marker.Auto());
+#else
+    internal struct Scope : IDisposable
+    {
+      [MethodImpl(MethodImplOptions.AggressiveInlining)]
+      public readonly void Dispose() { }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static Scope ConditionalAuto(this ProfilerMarker _) => default;
+#endif
   }
 }

--- a/Source/Utils.cs
+++ b/Source/Utils.cs
@@ -14,9 +14,30 @@ namespace SystemHeat
     Simulator,
     Any
   }
+
   public static class Utils
   {
-    public static string logTag = "SystemHeat";
+    public static readonly string logTag = "SystemHeat";
+
+    /// <summary>
+    /// Is logging enabled for a given subsystem? Use this to avoid formatting
+    /// calls if the logging wouldn't happen anyway.
+    /// </summary>
+    /// <param name="type"></param>
+    /// <returns></returns>
+    public static bool IsLogEnabled(LogType type)
+    {
+      return type switch
+      {
+        LogType.Settings => SystemHeatSettings.DebugSettings,
+        LogType.UI => SystemHeatSettings.DebugUI,
+        LogType.Modules => SystemHeatSettings.DebugModules,
+        LogType.Overlay => SystemHeatSettings.DebugOverlay,
+        LogType.Simulator => SystemHeatSettings.DebugSimulation,
+        LogType.Any => true,
+        _ => false
+      };
+    }
 
     /// <summary>
     /// Log a message with the mod name tag prefixed
@@ -25,31 +46,13 @@ namespace SystemHeat
     /// <param name="logType">the subsystem that is emitting this log</param>
     public static void Log(string str, LogType logType)
     {
-      bool doLog = false;
-      if (logType == LogType.Settings && SystemHeatSettings.DebugSettings) doLog = true;
-      if (logType == LogType.UI && SystemHeatSettings.DebugUI) doLog = true;
-      if (logType == LogType.Modules && SystemHeatSettings.DebugModules) doLog = true;
-      if (logType == LogType.Overlay && SystemHeatSettings.DebugOverlay) doLog = true;
-      if (logType == LogType.Simulator && SystemHeatSettings.DebugSimulation) doLog = true;
-      if (logType == LogType.Any) doLog = true;
-
-      if (doLog)
-        Debug.Log(String.Format("[{0}]{1}", logTag, str));
+      if (IsLogEnabled(logType))
+        Debug.Log($"[{logTag}]{str}");
     }
 
-    public static void Log(string str)
-    {
-      Debug.Log(String.Format("[{0}]{1}", logTag, str));
-    }
-
-      public static void LogWarning(string toLog)
-    {
-      Debug.LogWarning(String.Format("[{0}]{1}", logTag, toLog));
-    }
-    public static void LogError(string toLog)
-    {
-      Debug.LogError(String.Format("[{0}]{1}", logTag, toLog));
-    }
+    public static void Log(string str) => Debug.Log($"[{logTag}]{str}");
+    public static void LogWarning(string toLog) => Debug.LogWarning($"[{logTag}]{toLog}");
+    public static void LogError(string toLog) => Debug.LogError($"[{logTag}]{toLog}");
 
 
     /// <summary>


### PR DESCRIPTION
I'm gonna tackle #150 but decided to do a cleanup pass through`ModuleSystemHeat` first.

Here's what's included:
* A bunch of minor formatting things: fix indentation, weird spaces, etc
* Simplify some stuff that could use null coalescing
* Avoid calling `string.Format` if the log message is not enabled
* Initialize fluxes and temperatures in the constructor, then mark them readonly
* Delete `ChangeAllLoops` because it is dead code
* Change whole-method if statements to guard clauses

I have tested this and everything seems to work correctly, but there should also be no behaviour changes from this.