### PR TITLE
Add support for hot-reloading

### DIFF
--- a/Source/EngineerReport/SystemHeatEngineerReport.cs
+++ b/Source/EngineerReport/SystemHeatEngineerReport.cs
@@ -20,7 +20,18 @@ namespace SystemHeat
     {
       GameEvents.onGUIEngineersReportReady.Remove(ReportReady);
       GameEvents.onGUIEngineersReportDestroy.Remove(ReportDestroyed);
+
+      RemoveTest();
     }
+
+    // onGUIEngineersReportReady only fires once per editor session, so on a hot
+    // reload we need to re-add the tests manually here.
+    private void OnHotReload(MonoBehaviour old)
+    {
+      if (EngineersReport.Instance != null)
+        AddTest();
+    }
+
     private void AddTest()
     {
       //Wait for DeltaV simulation to be instantiated and to finish.
@@ -38,6 +49,9 @@ namespace SystemHeat
 
     private void RemoveTest()
     {
+      // EngineersReport may already be torn down on scene exit; tests are tied
+      // to its lifetime and don't need to be removed in that case.
+      if (EngineersReport.Instance == null) return;
 
       //Only if it was actually added, deregister it.
       if (tempTest != null) EngineersReport.Instance.RemoveTest(tempTest);

--- a/Source/Modules/ModuleSystemHeatColorAnimator.cs
+++ b/Source/Modules/ModuleSystemHeatColorAnimator.cs
@@ -84,7 +84,7 @@ namespace SystemHeat
     {
 
       targetRenderers = new List<Renderer>();
-      if (includedTransformList == "")
+      if (string.IsNullOrEmpty(includedTransformList))
       {
         foreach (Transform x in part.GetComponentsInChildren<Transform>())
         {

--- a/Source/SystemHeat.csproj
+++ b/Source/SystemHeat.csproj
@@ -29,6 +29,10 @@
     <PackageReference Include="KSPBuildTools" Version="1.1.1" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(Configuration)' == 'Debug' Or '$(Configuration)' == 'Profiling'">
+    <AssemblyMetadata Include="HotReload" Value="true" />
+  </ItemGroup>
+
   <ItemGroup>
     <Compile Remove="Modules\ModuleSystemHeatMultiJettison.cs" />
     <None Include="Modules\ModuleSystemHeatMultiJettison.cs" />

--- a/Source/SystemHeatEditor.cs
+++ b/Source/SystemHeatEditor.cs
@@ -40,6 +40,12 @@ namespace SystemHeat
       RemoveEditorCallbacks();
       Instance = null;
     }
+
+    private void OnHotReload(MonoBehaviour old)
+    {
+      if (HighLogic.LoadedSceneIsEditor && EditorLogic.fetch != null)
+        InitializeEditorConstruct(EditorLogic.fetch.ship, false);
+    }
     protected void FixedUpdate()
     {
       if (simulator != null)
@@ -51,7 +57,6 @@ namespace SystemHeat
           simulator.SimulationSpeed = SystemHeatUI.Instance.toolbarPanel.SimSituationVelocity;
         }
         simulator.SimulateEditor();
-        
       }
     }
     #region Editor

--- a/Source/SystemHeatGameSettings.cs
+++ b/Source/SystemHeatGameSettings.cs
@@ -5,7 +5,6 @@ namespace SystemHeat
 
   public class SystemHeatGameSettings_ReactorDamage : GameParameters.CustomParameterNode
   {
-
     [GameParameters.CustomParameterUI("AllowReactorDamage",
       title = "#LOC_SystemHeat_Settings_AllowReactorDamage_Title",
       toolTip = "#LOC_SystemHeat_Settings_AllowReactorDamage_Tooltip",

--- a/Source/SystemHeatSettings.cs
+++ b/Source/SystemHeatSettings.cs
@@ -127,6 +127,7 @@ namespace SystemHeat
     {
       return SystemHeatSettings.ColorData[Mathf.Clamp(id, 0, 9)];
     }
+
     /// <summary>
     /// Load data from configuration
     /// </summary>
@@ -216,5 +217,7 @@ namespace SystemHeat
         return new CoolantType();
       }
     }
+
+    static void OnHotLoad() => Load();
   }
 }

--- a/Source/UI/Overlay/SystemHeatOverlay.cs
+++ b/Source/UI/Overlay/SystemHeatOverlay.cs
@@ -69,6 +69,8 @@ namespace SystemHeat.UI
       GameEvents.onEditorStarted.Remove(onEditorStart);
       GameEvents.OnMapEntered.Remove(onEnterMapView);
       GameEvents.OnMapExited.Remove(onExitMapView);
+      ClearPanels();
+      DestroyOverlay();
       Instance = null;
 
     }

--- a/Source/UI/ReactorUI/ReactorToolbar.cs
+++ b/Source/UI/ReactorUI/ReactorToolbar.cs
@@ -212,7 +212,9 @@ namespace SystemHeat.UI
       if (stockToolbarButton != null)
       {
         ApplicationLauncher.Instance.RemoveModApplication(stockToolbarButton);
+        stockToolbarButton = null;
       }
+      DestroyToolbarPanel();
     }
 
     protected void OnToolbarButtonToggle()

--- a/Source/UI/SystemHeatAssets.cs
+++ b/Source/UI/SystemHeatAssets.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
 using UnityEngine;
 
 
@@ -20,6 +22,7 @@ namespace SystemHeat.UI
 
     internal static string ASSET_PATH = "GameData/SystemHeat/UI/systemheatui.dat";
     internal static string SPRITE_ATLAS_NAME = "system-heat-sprites-1";
+
     private void Awake()
     {
       Utils.Log("[SystemHeatAssets]: Loading Assets", LogType.UI);
@@ -41,6 +44,29 @@ namespace SystemHeat.UI
         Sprites.Add(subSprite.name, subSprite);
       }
       Utils.Log($"[SystemHeatAssets]: Loaded {Sprites.Count} sprites", LogType.UI);
+    }
+
+    // We can't load the asset bundle again - it is already loaded, and it would
+    // instantiate the old types. Instead, we use reflection to read them out of
+    // the old assembly. Hot-reloading will take care of replacing any widgets
+    // within.
+    private static void OnHotLoad(Assembly prev)
+    {
+      const BindingFlags Flags = BindingFlags.Public | BindingFlags.Static;
+
+      var old = prev.GetType(typeof(SystemHeatAssets).FullName);
+      OverlayPanelPrefab = GetPrefabProperty(old, nameof(OverlayPanelPrefab));
+      ToolbarPanelPrefab = GetPrefabProperty(old, nameof(ToolbarPanelPrefab));
+      ToolbarPanelLoopPrefab = GetPrefabProperty(old, nameof(ToolbarPanelLoopPrefab));
+      ReactorWidgetPrefab = GetPrefabProperty(old, nameof(ReactorWidgetPrefab));
+      ReactorToolbarPanelPrefab = GetPrefabProperty(old, nameof(ReactorToolbarPanelPrefab));
+      Sprites = (Dictionary<string, Sprite>)old.GetProperty(nameof(Sprites), Flags).GetValue(null);
+    }
+
+    private static GameObject GetPrefabProperty(Type old, string name)
+    {
+      const BindingFlags Flags = BindingFlags.Public | BindingFlags.Static;
+      return (GameObject)old.GetProperty(name, Flags).GetValue(null);
     }
   }
 }

--- a/Source/UI/SystemHeatUI.cs
+++ b/Source/UI/SystemHeatUI.cs
@@ -50,8 +50,14 @@ namespace SystemHeat.UI
     {
       if (ApplicationLauncher.Ready)
         OnGUIAppLauncherReady();
+    }
 
-
+    // Explicitly destroy the toolbar panel because hot-reloading will destroy
+    // the old component but leave the panel game object orphaned.
+    private void OnHotReload(MonoBehaviour old)
+    {
+      DestroyToolbarPanel();
+      toolbarPanel = null;
     }
 
     protected void CreateToolbarPanel()
@@ -264,11 +270,12 @@ namespace SystemHeat.UI
     {
       Utils.Log("[UI]: OnDestroy Fired", LogType.UI);
       // Remove the stock toolbar button
-      GameEvents.onGUIApplicationLauncherReady.Remove(OnGUIAppLauncherReady);
       if (stockToolbarButton != null)
       {
         ApplicationLauncher.Instance.RemoveModApplication(stockToolbarButton);
+        stockToolbarButton = null;
       }
+      DestroyToolbarPanel();
       GameEvents.onGUIApplicationLauncherReady.Remove(OnGUIAppLauncherReady);
       GameEvents.onGUIApplicationLauncherDestroyed.Remove(OnGUIAppLauncherDestroyed);
       GameEvents.onGUIApplicationLauncherUnreadifying.Remove(new EventData<GameScenes>.OnEvent(OnGUIAppLauncherUnreadifying));


### PR DESCRIPTION
Most of the changes here are just properly unregistering stuff when being destroyed, but there were a few explicit callbacks needed and it also uncovered a number of cases where HotReloadKSP wasn't quite handling things correctly.

The explicit new changes to support reload are:
* Load SystemHeatSettings when hot-loaded
* Destroy the UI when SystemHeatUI is destroyed
* Explicitly recreate the editor UI when hot-reloaded.
* We need to explicitly grab the prefab objects from the old assembly. Hot reloading still takes care of replacing any widgets within.

Getting this to work requires HotReloadKSP v0.1.4