### PR TITLE
Properly update the converter status in the editor

### DIFF
--- a/Source/Modules/ModuleSystemHeatConverter.cs
+++ b/Source/Modules/ModuleSystemHeatConverter.cs
@@ -87,6 +87,7 @@ namespace SystemHeat
       }
       else
       {
+        UpdateConverterStatus();
         UpdateFlux();
         Fields["ConverterEfficiency"].guiActiveEditor = editorThermalSim;
       }


### PR DESCRIPTION
We were skipping the entirety of ModuleResourceConverter.FixedUpdate. Turns out it was actually doing some work that needed to be done. This fixes that by manually calling UpdateConverterStatus.

Fixes #174